### PR TITLE
Fix chat scroll behavior

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -20,9 +20,6 @@ document.body.addEventListener('htmx:beforeRequest', function(event) {
     // Append typing indicator
     var typingIndicator = document.getElementById('typing-indicator').content.cloneNode(true);
     chatContainer.appendChild(typingIndicator);
-    
-    // Scroll to bottom
-    chatContainer.scrollTop = chatContainer.scrollHeight;
 });
 
 document.body.addEventListener('htmx:afterSwap', function(event) {
@@ -42,13 +39,4 @@ document.body.addEventListener('htmx:afterSwap', function(event) {
     
     // Add 'show' class to trigger animation
     newMessage.classList.add('show');
-    
-    // Scroll to bottom
-    chatContainer.scrollTop = chatContainer.scrollHeight;
 });
-
-// Scroll to bottom on page load
-window.onload = function() {
-    var chatContainer = document.getElementById('chat-container');
-    chatContainer.scrollTop = chatContainer.scrollHeight;
-};


### PR DESCRIPTION
Closes #15

Update `app/static/script.js` to display the top of the chat message initially instead of scrolling to the bottom.

* **Remove scroll to bottom after new message**: Remove the code that scrolls the chat container to the bottom after a new message is added in the `htmx:beforeRequest` and `htmx:afterSwap` event listeners.
* **Remove scroll to bottom on page load**: Remove the `window.onload` function that scrolls the chat container to the bottom on page load.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brylie/langflow-fastapi-htmx/issues/15?shareId=40ed82d0-d937-4b3b-b33e-644f859a3d5f).