### PR TITLE
Add GitHub Action for automated unit testing on pull requests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,33 @@
+name: Python Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run pytest
+      run: pytest

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ http://127.0.0.1:8000
 
 You should now see the chat interface and be able to interact with the chatbot.
 
+## Continuous Integration (CI) Process
+
+We use GitHub Actions to automatically run our pytest suite on every pull request to the main branch. This ensures that all tests pass before changes can be merged.
+
+### CI Status Badge
+
+![CI Status](https://github.com/brylie/langflow-fastapi-htmx/actions/workflows/pytest.yml/badge.svg)
+
 ## Development
 
 - The main application code is in `chat.py`.


### PR DESCRIPTION
Related to #12

Add GitHub Action for Automated Unit Testing on Pull Requests

* Create `.github/workflows/pytest.yml` to configure the GitHub Action.
  * Trigger on pull requests to the main branch.
  * Run on the latest Ubuntu runner.
  * Set up the Python environment with Python 3.10.
  * Cache pip dependencies to speed up subsequent runs.
  * Install project dependencies.
  * Run pytest.

* Update `README.md` to include information about the CI process.
  * Add a section about the CI process.
  * Include a badge for the test status.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brylie/langflow-fastapi-htmx/issues/12?shareId=75101c5a-5367-41c9-ac16-cb3288dd5788).