### PR TITLE
Implement auto-scroll to top of message for new chat messages

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -40,3 +40,25 @@ document.body.addEventListener('htmx:afterSwap', function(event) {
     // Add 'show' class to trigger animation
     newMessage.classList.add('show');
 });
+
+function scrollToLastMessage() {
+    const chatContainer = document.getElementById('chat-container');
+    const lastMessage = chatContainer.lastElementChild;
+    if (lastMessage) {
+        lastMessage.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+const chatContainer = document.getElementById('chat-container');
+const observer = new MutationObserver((mutations) => {
+    for (let mutation of mutations) {
+        if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+            scrollToLastMessage();
+            break;
+        }
+    }
+});
+
+observer.observe(chatContainer, { childList: true });
+
+document.addEventListener('DOMContentLoaded', scrollToLastMessage);


### PR DESCRIPTION
Related to #22

Implement auto-scroll to the top of the newest message when new messages are added to the chat.

* Add a new JavaScript function `scrollToLastMessage` to handle scrolling to the newest message.
* Implement a `MutationObserver` to watch for changes in the chat container and trigger `scrollToLastMessage` when new messages are added.
* Update the `DOMContentLoaded` event listener to call `scrollToLastMessage` when the page loads.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brylie/langflow-fastapi-htmx/issues/22?shareId=8047a0a3-e328-4059-a851-cd467bdbddef).